### PR TITLE
Logout em botão 'Sair da conta' em dashboard de admin

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -31,7 +31,7 @@ export default function Admin() {
         <div className="text-center mt-20">
           <div className="pt-4 md:pt-6">
             <Button
-              href={`${process.env.APP_URL}/produtos`}
+              href={`${process.env.APP_URL}/logout`}
               className="md:text-lg px-4 py-2 md:py-4 md:px-8"
             >
               Sair da conta


### PR DESCRIPTION
No botão 'Sair da conta', rota foi alterada para '/logout', de forma a direcionar usuário à saída de conta.