### PR TITLE
Feature/colorir lupa de pesquisa

### DIFF
--- a/src/components/pages/checkout/AddressCheckoutForm.tsx
+++ b/src/components/pages/checkout/AddressCheckoutForm.tsx
@@ -79,7 +79,7 @@ export default function AddressCheckoutForm(attrs: any) {
   return (
     <>
       <div className="grid gap-2">
-        <div className="relative">
+        <div className="relative"> 
           <input
             name="cep"
             onChange={(e: any) => setZipCode(formatCep(e.target.value))}


### PR DESCRIPTION
Foi incluída classe de botão para que ícone de busca com lupa se tornasse mais visível, assumindo a identidade visual do Fiestou.
![image](https://github.com/user-attachments/assets/3bdb42c9-809a-43f1-85e4-3ad882dbf441)
 