### PR TITLE
Ajuste em layout de primeira linha de grupos em filtro

### DIFF
--- a/src/components/common/Filter.tsx
+++ b/src/components/common/Filter.tsx
@@ -356,23 +356,36 @@ export default function Filter(params: { store?: string; busca?: string }) {
               <div className={`flex md:flex-wrap gap-2 ${groupIndex === 0 ? "space-x-2" : ""}`}>
                 {group.elements.map((element: Element, index: number) => (
                   <div
-                    key={index}
-                    className={`border cursor-pointer ease relative rounded p-2 ${element.checked ? "border-zinc-800 hover:border-zinc-500" : "hover:border-zinc-300"
-                      } ${groupIndex === 0 ? "flex flex-col items-center p-4 w-[90px]" : ""}`}
-                    onClick={() => {
-                      onClickElementFilter(element.id, element.checked, element.descendants || []);
-                    }}
-                  >
-                    <div className={`flex items-center gap-2 ${groupIndex === 0 ? "flex-col" : ""}`}>
+                  key={index}
+                  className={`
+                    border cursor-pointer ease relative rounded
+                    ${element.checked 
+                      ? "border-zinc-800 hover:border-zinc-500" 
+                      : "hover:border-zinc-300"
+                    }
+                    flex flex-col items-center p-2 w-auto
+                  `}
+                  onClick={() => {
+                    onClickElementFilter(element.id, element.checked, element.descendants || []);
+                  }}
+                >
+                    <div className={`flex items-center gap-2 ${groupIndex === 0 ? "flex-col" : "flex-row whitespace-nowrap"}`}>
                       {element.icon && (
                         <Img
                           src={element.icon}
-                          className={`object-contain ${groupIndex === 0 ? "h-[40px] w-[40px]" : "h-[20px] w-[20px]"}`}
+                          className={`object-contain ${
+                            groupIndex === 0 
+                              ? "h-[40px] w-[40px]" 
+                              : "h-[20px] w-[20px] flex-shrink-0"
+                          }`}
                         />
                       )}
                       <div
-                        className={`whitespace-nowrap text-sm md:text-base ${groupIndex === 0 ? "text-center font-medium" : ""
-                          }`}
+                        className={`text-sm md:text-base ${
+                          groupIndex === 0 
+                            ? "text-center font-medium" 
+                            : "font-normal whitespace-nowrap"
+                        }`}
                       >
                         {element.name}
                       </div>


### PR DESCRIPTION
[Task mãe] BUG 1109 - [Homolog] Fazer primeiro Grupo de Filtro ter Elementos com um layout mais chamativo:
https://dev.azure.com/leadsoft-dev/LeadSoft/_sprints/backlog/Squad%20Cosmonautas/LeadSoft/Sprint%2020?System.AssignedTo=junnyldo.costa%40leadsoft.inf.br&workitem=1109

[Task 1118] - Ajustar texto para caber dentro do espaço disponível ou aumentar o tamanho horizontal do card do Elemento:
https://dev.azure.com/leadsoft-dev/LeadSoft/_sprints/taskboard/Squad%20Cosmonautas/LeadSoft/Sprint%2020?System.AssignedTo=%40me&workitem=1118

Conforme solicitado, classes foram ajustadas para que dimensão de card se adequa a conteúdo interno, mantendo imagem no topo e texto abaixo da imagem, alargando horizontalmente ou mantendo a dimensão mínima necessária.

![image](https://github.com/user-attachments/assets/66dd1b55-a360-4f04-8938-dec83d7244ce)
