### PR TITLE
Correção em footer

### DIFF
--- a/pages/produtos/[slug]/index.tsx
+++ b/pages/produtos/[slug]/index.tsx
@@ -404,8 +404,6 @@ export default function Produto({
       },
     });
 
-    console.log(request, "request");
-
     setMatch(request?.data ?? []);
   };
 
@@ -963,12 +961,11 @@ export default function Produto({
                         )}
                       </div>
                     </div>
-                  </div>
+                  </div> 
 
-                  <div className={`bg-white ${layout.isMobile ? 'relative' : 'drop-shadow-2xl fixed z-[20] -mx-4 w-full left-0 bottom-0'} md:drop-shadow-none md:relative md:w-auto flex justify-between`}>
+                  <div className="bg-white relative w-full mb-6">
                     {!!productToCart?.total && (
-                      <>
-                        <div className="leading-tight self-center w-full px-4">
+                      <div className="leading-tight w-full">
                         <div>
                           <strong className="text-zinc-950">
                           {!!product?.availability && (
@@ -986,7 +983,15 @@ export default function Produto({
                           <p>Esse produto é entregue em até <strong>{product?.availability}{" "}</strong>
                           dia
                           {Number(product?.availability || 0) > 1 ? `s` : ""}.</p>
-                        </div><br />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="bg-white drop-shadow-2xl md:drop-shadow-none fixed z-[20] md:-mx-4 md:relative w-full md:w-auto left-0 bottom-0 flex justify-between">
+                    {!!productToCart?.total && (
+                      <>
+                        <div className="leading-tight self-center w-full px-4">
                           <div className="text-xs">
                             {!!productToCart?.details?.dateStart
                               ? dateBRFormat(productToCart?.details?.dateStart)
@@ -1000,8 +1005,7 @@ export default function Produto({
 
                         <div className="text-center p-4">
                           {!inCart ? (
-                            <Button
-                            >
+                            <Button>
                               Adicionar
                             </Button>
                           ) : (


### PR DESCRIPTION
Task principal 929 - Realçar mais a opção "Tempo de entrega" quando estiver configurada: https://dev.azure.com/leadsoft-dev/LeadSoft/_workitems/edit/929
Task secundária 1122 - [homolog] Quando o tempo de entrega é de um dia a informação não é exibida corretamente: https://dev.azure.com/leadsoft-dev/LeadSoft/_sprints/taskboard/Squad%20Cosmonautas/LeadSoft/Sprint%2020?System.AssignedTo=%40me&workitem=1122

Conforme solicitado, ajuste realizado em homolog de task 929. Como se pode observar na captura de tela abaixo, apenas as informações 'Selecione a data' ou data, preço do pedido e botão adicionar no footer. Também foi realizado ajuste para que quando o prazo de entrega for de até 1 dia, o comportamento seja o esperado, além do destaque ao número de dia(s).

![image](https://github.com/user-attachments/assets/f991f95d-9bde-4d0d-9708-4805023de4e1)
