### PR TITLE
Corrigindo problema em disponibilidade de 1 dia

### DIFF
--- a/pages/produtos/[slug]/index.tsx
+++ b/pages/produtos/[slug]/index.tsx
@@ -968,21 +968,26 @@ export default function Produto({
                       <div className="leading-tight w-full">
                         <div>
                           <strong className="text-zinc-950">
-                          {!!product?.availability && (
-                            <div className="flex gap-2 items-center">
-                              <div className="w-[1.25rem] flex justify-center">
-                                <Icon
-                                  icon="fa-truck"
-                                  type="far"
-                                  className="text-yellow-400 text-base"
-                                />
-                              </div>Entrega
-                            </div>
-                          )}
-                          </strong><br />{" "}
-                          <p>Esse produto é entregue em até <strong>{product?.availability}{" "}</strong>
-                          dia
-                          {Number(product?.availability || 0) > 1 ? `s` : ""}.</p>
+                            {(product?.availability ?? 1) >= 1 && (
+                              <div className="flex gap-2 items-center">
+                                <div className="w-[1.25rem] flex justify-center">
+                                  <Icon
+                                    icon="fa-truck"
+                                    type="far"
+                                    className="text-yellow-400 text-base"
+                                  />
+                                </div>
+                                Entrega
+                              </div>
+                            )}
+                          </strong>
+                          <br />{" "}
+                          <p>
+                            Esse produto é entregue em até{" "}
+                            <strong>{product?.availability ?? 1}{" "}</strong>
+                            dia
+                            {Number(product?.availability ?? 1) > 1 ? "s" : ""}.
+                          </p>
                         </div>
                       </div>
                     )}


### PR DESCRIPTION
Task mãe **929 - Realçar mais a opção "Tempo de entrega" quando estiver configurada**: https://dev.azure.com/leadsoft-dev/LeadSoft/_sprints/taskboard/Squad%20Cosmonautas/LeadSoft/Sprint%2020?System.AssignedTo=%40me&workitem=929
Task secundária **1122 - [homolog] Quando o tempo de entrega é de um dia a informação não é exibida corretamente**: https://dev.azure.com/leadsoft-dev/LeadSoft/_sprints/taskboard/Squad%20Cosmonautas/LeadSoft/Sprint%2020?System.AssignedTo=%40me&workitem=1122

Garantiu-se que sempre haverá valor numérico, nunca um 'undefined'. Também se garantiu de que a condicional '(product?.availability ?? 1) >= 1' seja sempre verdadeira. Assim, fica validado que, ainda que usuário use disponibilidade default, o texto e ícone se comportarão como esperado.

![teste_produto_default](https://github.com/user-attachments/assets/08771d98-c16b-4975-9c27-e472438b4194)
![teste_produto_default_verificado](https://github.com/user-attachments/assets/9a0de884-9761-4a37-b325-e7d94c429fce)
