### PR TITLE
Substituição de 'slug' de produtos por 'id' de produtos

### DIFF
--- a/pages/carrinho/index.tsx
+++ b/pages/carrinho/index.tsx
@@ -199,7 +199,7 @@ export default function Carrinho({
                           <div className="flex gap-10 items-start">
                             <div className="w-full">
                               <h5 className="font-title font-bold text-zinc-900 text-xl">
-                                <Link href={`/produtos/${item.product?.slug}`}>
+                                <Link href={`/produtos/${item.product?.id}`}>
                                   {item.product.title}
                                 </Link>
                               </h5>

--- a/pages/dashboard/pedidos/[id]/index.tsx
+++ b/pages/dashboard/pedidos/[id]/index.tsx
@@ -330,7 +330,7 @@ export default function Pedido({
                             </div>
                             <div className="grid gap-1 w-full">
                               <div className="font-title text-lg font-bold text-zinc-900">
-                              <Link href={`/produtos/${product?.slug}`}>
+                              <Link href={`/produtos/${product?.id}`}>
                                 {product.title}
                               </Link>
                             </div>

--- a/pages/dashboard/pedidos/pagamento/[id]/index.tsx
+++ b/pages/dashboard/pedidos/pagamento/[id]/index.tsx
@@ -589,7 +589,7 @@ export default function Pagamento({
                               </div>
                               <div className="grid gap-1 w-full">
                                 <div className="font-title text-lg font-bold text-zinc-900">
-                                  <Link href={`/produtos/${product?.slug}`}>
+                                  <Link href={`/produtos/${product?.id}`}>
                                     {product.title}
                                   </Link>
                                 </div>


### PR DESCRIPTION
Substituição de 'product?.slug' por '{product?.id' em arquivos, para se adequar à nova estrutura.

Task relacionada: https://dev.azure.com/leadsoft-dev/LeadSoft/_sprints/taskboard/Squad%20Cosmonautas/LeadSoft/Sprint%2024?System.AssignedTo=%40me%2Cjunnyldo.costa%40leadsoft.inf.br&workitem=931